### PR TITLE
[#5] Configure unit tests and integration test plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,28 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                    <additionalClasspathElements>
+                        <additionalClasspathElement>{basedir}/target/classes</additionalClasspathElement>
+                    </additionalClasspathElements>
+                    <parallel>none</parallel>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/it/cinemabackend/example/Example.java
+++ b/src/main/java/com/it/cinemabackend/example/Example.java
@@ -1,0 +1,10 @@
+package com.it.cinemabackend.example;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class Example {
+    public Integer add(Integer a, Integer b) {
+        return a + b;
+    }
+}

--- a/src/test/java/com/it/cinemabackend/CinemaBackendApplicationIT.java
+++ b/src/test/java/com/it/cinemabackend/CinemaBackendApplicationIT.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class CinemaBackendApplicationTests {
+class CinemaBackendApplicationIT {
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/it/cinemabackend/example/ExampleTest.java
+++ b/src/test/java/com/it/cinemabackend/example/ExampleTest.java
@@ -1,0 +1,24 @@
+package com.it.cinemabackend.example;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExampleTest {
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void add() {
+        Example example = new Example();
+        assertEquals(10, example.add(5, 5));
+    }
+}


### PR DESCRIPTION
Unit tests now will be run in test stage of lifecycle,
and integral tests will be run by failsafe:integration-test
or in verify stage of lifecycle just after unit tests.

Probably we should add separate lifecycle stage named
integration-tests.